### PR TITLE
Updated alembic 'compare_for_table' to ignore tables that are not in …

### DIFF
--- a/src/sqlalchemy_postgresql_audit/event_listeners/alembic.py
+++ b/src/sqlalchemy_postgresql_audit/event_listeners/alembic.py
@@ -14,6 +14,11 @@ class ReversableExecute(ExecuteSQLOp):
 def compare_for_table(
     autogen_context, modify_table_ops, schema, tname, conn_table, metadata_table
 ):
+    # Early exit if there is no metadata table or we can't get it's info.
+    # This handles alembic version tables, but also others.
+    if metadata_table is None or not hasattr(metadata_table, "info"):
+        return
+
     if metadata_table.info.get("audit.is_audit_table"):
         # Case when the audit table is new
         if conn_table is None:

--- a/tests/unit_tests/test_enabled_option.py
+++ b/tests/unit_tests/test_enabled_option.py
@@ -1,0 +1,19 @@
+from sqlalchemy import MetaData, Table, Column, Integer
+import sqlalchemy_postgresql_audit
+
+
+def test_audit_table_gets_added():
+
+    sqlalchemy_postgresql_audit.enable()
+    metadata = MetaData()
+    table = Table(
+        "foo",
+        metadata,
+        Column("bar", Integer),
+        info={"audit.options": {"enabled": True}},
+    )
+
+    audit_table = metadata.tables["foo_audit"]
+
+    assert audit_table.info["audit.is_audit_table"]
+    assert table.info["audit.is_audited"]


### PR DESCRIPTION
…the metadata or do not have an info attribute